### PR TITLE
Finalize recording state policy

### DIFF
--- a/src/uca-camera.c
+++ b/src/uca-camera.c
@@ -1100,7 +1100,7 @@ uca_camera_trigger (UcaCamera *camera, GError **error)
 
     g_mutex_lock (&mutex);
 
-    if (!uca_camera_is_recording (camera)) {
+    if (!camera->priv->is_recording) {
         g_set_error (error, UCA_CAMERA_ERROR, UCA_CAMERA_ERROR_NOT_RECORDING, "Camera is not recording");
     }
     else {


### PR DESCRIPTION
This change fixes and unifies handling of different "is-recording" states. First
of all there are potentially two different states: the priv->is_recording state
from the base class and some device-specific state. Device authors can override
the "is-recording" property to provide device-specific information. This change
sets the global recording state as follows:
1. uca_camera_is_recording returns the value of ::is-recording.
2. priv->is_recording is the default state that is returned for ::is-recording
   and set after successfully calling uca_camera_start_recording and
   uca_camera_stop_recording.
3. uca_camera_start_recording, uca_camera_stop_recording, uca_camera_trigger
   use ::is-recording to determine how to proceed.
4. For performance reasons, uca_camera_grab relies on priv->is_recording.
