### PR TITLE
Release GIL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,20 @@ set_target_properties(uca PROPERTIES
 
 target_link_libraries(uca ${UCA_DEPS})
 #}}}
+#{{{ Python
+
+pkg_check_modules(PYTHON python)
+
+if (PYTHON_FOUND)
+    option(WITH_PYTHON_MULTITHREADING "Enable Python multithreading support" ON)
+
+    if (WITH_PYTHON_MULTITHREADING)
+        include_directories(${PYTHON_INCLUDE_DIRS})
+        target_link_libraries(uca ${PYTHON_LIBRARIES})
+    endif ()
+endif ()
+
+#}}}
 #{{{ GObject introspection
 if (INTROSPECTION_SCANNER AND INTROSPECTION_COMPILER)
     option(WITH_GIR "Build introspection files" ON)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,3 +1,4 @@
+#cmakedefine WITH_PYTHON_MULTITHREADING     1
 #cmakedefine HAVE_PCO_CL
 #cmakedefine HAVE_PHOTON_FOCUS
 #cmakedefine HAVE_PHOTRON_FASTCAM


### PR DESCRIPTION
As discussed in https://github.com/ufo-kit/concert/issues/341, this PR releases the Python GIL on each (synchronous) grab call. Releasing the GIL for buffered grab is unnecessary because data is grabbed in another thread anyway.
