### PR TITLE
get_camerah interface

### DIFF
--- a/src/uca-plugin-manager.h
+++ b/src/uca-plugin-manager.h
@@ -55,6 +55,10 @@ void                 uca_plugin_manager_add_path    (UcaPluginManager   *manager
                                                      const gchar        *path);
 GList               *uca_plugin_manager_get_available_cameras
                                                     (UcaPluginManager   *manager);
+UcaCamera           *uca_plugin_manager_get_camerah (UcaPluginManager   *manager,
+                                                     const gchar        *name,
+                                                     GHashTable         *parameters,
+                                                     GError            **error);
 UcaCamera           *uca_plugin_manager_get_camerav (UcaPluginManager   *manager,
                                                      const gchar        *name,
                                                      guint               n_parameters,

--- a/test/test-mock.c
+++ b/test/test-mock.c
@@ -291,6 +291,41 @@ test_can_be_written (Fixture *fixture, gconstpointer data)
     g_assert_no_error (error);
 }
 
+static void
+test_factory_hashtable (Fixture *fixture, gconstpointer data)
+{
+    GError *error = NULL;
+
+    guint checkvalue = 42;
+
+    gchar *foo = "roi-width";
+    gchar *bar = "roi-height";
+    GValue baz = G_VALUE_INIT;
+    g_value_init(&baz, G_TYPE_UINT);
+    g_value_set_uint(&baz, checkvalue);
+
+    GHashTable *ght = g_hash_table_new (NULL, NULL);
+    g_hash_table_insert(ght, foo, &baz);
+    g_hash_table_insert(ght, bar, &baz);
+
+    UcaCamera *camera = uca_plugin_manager_get_camerah (fixture->manager,
+                                                     "mock", ght, &error);
+    g_hash_table_destroy(ght);
+
+    g_assert (error == NULL);
+    g_assert (camera);
+
+    guint roi_width = 0;
+    g_object_get (G_OBJECT (camera), "roi-width", &roi_width, NULL);
+    g_assert (roi_width == checkvalue);
+
+    guint roi_height = 0;
+    g_object_get (G_OBJECT (camera), "roi-height", &roi_height, NULL);
+    g_assert (roi_height == checkvalue);
+
+    g_object_unref(camera);
+}
+
 int main (int argc, char *argv[])
 {
     gsize n_tests;
@@ -308,6 +343,7 @@ int main (int argc, char *argv[])
     }
     tests[] = {
         {"/factory", test_factory},
+        {"/factory/hashtable", test_factory_hashtable},
         {"/signal", test_signal},
         {"/recording", test_recording},
         {"/recording/signal", test_recording_signal},


### PR DESCRIPTION
Adde _get_camerah_ interface to the _uca_plugin_manager_.
This interface actually allows to pass parameters to the camera that is about to be created, from the Python binding. The old _get_camerav_ interface was unable to do that, since it is currently impossible to create a sane GParameter in Python... It is, however, possible to create a GHashTable. So i use that one as a middle layer to build GParameters inside the C-world and pass them to the _get_camerav_ afterwards
I will later on need that interface for the kiro camera plugin.
