### PR TITLE
Changed GUI to do hard frame skipping in preview mode

### DIFF
--- a/src/uca-camera.c
+++ b/src/uca-camera.c
@@ -522,7 +522,7 @@ uca_camera_class_init (UcaCameraClass *klass)
             FALSE, G_PARAM_READABLE);
 
     /**
-     * UcaCamera:recorded-frames
+     * UcaCamera:recorded-frames:
      *
      * Number of frames that are recorded into internal camera memory.
      *


### PR DESCRIPTION
Our camera guys were asking me if there was a way to remove the internal buffering from the preview mode of the camera-control GUI, because it was introducing enormous delays. Strangely, the GUI already had a one-to-one relation between ```grab``` command and display ```refresh``` iteration, but still there was a large delay.
As per their request, I still changed the preview mechanism to an _async-grab / sync-draw_ and now it is apparently a lot better. Perhaps the problem is somewhere within the ```uca_camera_grab``` mechanism or even the ```pcilib``` driver, which buffers internally when using ```EXTERNAL``` or ```AUTO``` triggering? However, it appears to help to asynchronously _grab_ as fast as the system can and it doesn't change the external behavior of the GUI, so I guess we can make this the default.
Hence, here's the pull request for that.