### PR TITLE
Mock dynamic size

### DIFF
--- a/bin/gui/egg-property-cell-renderer.c
+++ b/bin/gui/egg-property-cell-renderer.c
@@ -124,6 +124,8 @@ egg_property_cell_renderer_set_renderer (EggPropertyCellRenderer    *renderer,
     priv = EGG_PROPERTY_CELL_RENDERER_GET_PRIVATE (renderer);
     pspec = get_pspec_from_object (priv->object, prop_name);
 
+    gboolean writable = (pspec->flags & G_PARAM_WRITABLE) && !(pspec->flags & G_PARAM_CONSTRUCT_ONLY);
+
     /*
      * Set this renderers mode, so that any actions can be forwarded to our
      * child renderers.
@@ -181,7 +183,7 @@ egg_property_cell_renderer_set_renderer (EggPropertyCellRenderer    *renderer,
                 g_object_get (priv->object, prop_name, &val, NULL);
                 g_object_set (priv->renderer,
                         "active", val,
-                        "activatable", pspec->flags & G_PARAM_WRITABLE ? TRUE : FALSE,
+                        "activatable", writable, 
                         NULL);
                 break;
             }
@@ -251,7 +253,8 @@ egg_property_cell_renderer_set_renderer (EggPropertyCellRenderer    *renderer,
             break;
     }
 
-    if (pspec->flags & G_PARAM_WRITABLE) {
+
+    if (writable) {
         if (GTK_IS_CELL_RENDERER_TOGGLE (priv->renderer))
             g_object_set (priv->renderer, "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE, NULL);
         else

--- a/plugins/mock/CMakeLists.txt
+++ b/plugins/mock/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ucamock C)
 set(UCA_CAMERA_NAME "mock")
 set(PLUGIN_VERSION "1.0.2")
 set(PLUGIN_REVISION "1")
-set(PLUGIN_REQUIRES "libuca >= 2.0.0")
+set(PLUGIN_REQUIRES "libuca >= 2.1.0")
 set(PLUGIN_SUMMARY "Mock plugin for libuca")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in

--- a/src/uca-camera.c
+++ b/src/uca-camera.c
@@ -372,15 +372,15 @@ uca_camera_class_init (UcaCameraClass *klass)
         g_param_spec_uint(uca_camera_props[PROP_SENSOR_WIDTH],
             "Width of sensor",
             "Width of the sensor in pixels",
-            1, G_MAXUINT, 1,
-            G_PARAM_READABLE);
+            1, G_MAXUINT, 512,
+            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 
     camera_properties[PROP_SENSOR_HEIGHT] =
         g_param_spec_uint(uca_camera_props[PROP_SENSOR_HEIGHT],
             "Height of sensor",
             "Height of the sensor in pixels",
-            1, G_MAXUINT, 1,
-            G_PARAM_READABLE);
+            1, G_MAXUINT, 512,
+            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 
     camera_properties[PROP_SENSOR_PIXEL_WIDTH] =
         g_param_spec_double (uca_camera_props[PROP_SENSOR_PIXEL_WIDTH],
@@ -400,8 +400,8 @@ uca_camera_class_init (UcaCameraClass *klass)
         g_param_spec_uint(uca_camera_props[PROP_SENSOR_BITDEPTH],
             "Number of bits per pixel",
             "Number of bits per pixel",
-            1, 32, 1,
-            G_PARAM_READABLE);
+            1, 32, 8,
+            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 
     camera_properties[PROP_SENSOR_HORIZONTAL_BINNING] =
         g_param_spec_uint(uca_camera_props[PROP_SENSOR_HORIZONTAL_BINNING],
@@ -1154,7 +1154,24 @@ uca_camera_set_writable (UcaCamera *camera,
     GParamSpec *pspec;
 
     pspec = get_param_spec_by_name (camera, prop_name);
+    uca_camera_pspec_set_writable (pspec, writable);
+}
 
+/**
+ * uca_camera_pspec_set_writable: (skip)
+ * @pspec: A #GParamSpec
+ * @writable: %TRUE if property can be written during acquisition
+ *
+ * Sets a flag that defines if the property defined by @pspec can be written
+ * during an acquisition. This can be used during UcaCamera class
+ * initialization.
+ *
+ * Since: 2.1
+ */
+void
+uca_camera_pspec_set_writable (GParamSpec *pspec,
+                               gboolean writable)
+{
     if (pspec != NULL) {
         if (g_param_spec_get_qdata (pspec, UCA_WRITABLE_QUARK) != NULL)
             g_warning ("::%s is already fixed", pspec->name);

--- a/src/uca-camera.h
+++ b/src/uca-camera.h
@@ -179,6 +179,9 @@ UcaUnit     uca_camera_get_unit         (UcaCamera          *camera,
 void        uca_camera_set_writable     (UcaCamera          *camera,
                                          const gchar        *prop_name,
                                          gboolean            writable);
+void        uca_camera_pspec_set_writable
+                                        (GParamSpec         *pspec,
+                                         gboolean            writable);
 gboolean    uca_camera_is_writable_during_acquisition
                                         (UcaCamera          *camera,
                                          const gchar        *prop_name);

--- a/test/test-mock.c
+++ b/test/test-mock.c
@@ -287,8 +287,9 @@ test_can_be_written (Fixture *fixture, gconstpointer data)
     g_assert_no_error (error);
     g_object_set (fixture->camera, "roi-height", 128, NULL);
 #if (GLIB_CHECK_VERSION (2, 34, 0))
-    g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Property 'exposure-time' cant be changed during acquisition");
-    g_object_set (fixture->camera, "exposure-time", 1.0, NULL);
+    uca_camera_set_writable (fixture->camera, "roi-x0", FALSE);
+    g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Property 'roi-x0' cant be changed during acquisition");
+    g_object_set (fixture->camera, "roi-x0", 64, NULL);
     g_test_assert_expected_messages ();
 #endif
     uca_camera_stop_recording (fixture->camera, &error);
@@ -302,8 +303,8 @@ test_factory_hashtable (Fixture *fixture, gconstpointer data)
 
     guint checkvalue = 42;
 
-    gchar *foo = "roi-width";
-    gchar *bar = "roi-height";
+    gchar *foo = "roi-x0";
+    gchar *bar = "roi-y0";
     GValue baz = G_VALUE_INIT;
     g_value_init(&baz, G_TYPE_UINT);
     g_value_set_uint(&baz, checkvalue);
@@ -319,13 +320,13 @@ test_factory_hashtable (Fixture *fixture, gconstpointer data)
     g_assert (error == NULL);
     g_assert (camera);
 
-    guint roi_width = 0;
-    g_object_get (G_OBJECT (camera), "roi-width", &roi_width, NULL);
-    g_assert (roi_width == checkvalue);
+    guint roi_x0 = 0;
+    g_object_get (G_OBJECT (camera), "roi-x0", &roi_x0, NULL);
+    g_assert (roi_x0 == checkvalue);
 
-    guint roi_height = 0;
-    g_object_get (G_OBJECT (camera), "roi-height", &roi_height, NULL);
-    g_assert (roi_height == checkvalue);
+    guint roi_y0 = 0;
+    g_object_get (G_OBJECT (camera), "roi-y0", &roi_y0, NULL);
+    g_assert (roi_y0 == checkvalue);
 
     g_object_unref(camera);
 }


### PR DESCRIPTION
I have changed mock camera so that it is possible to set ```sensor-width```, ```sensor-height``` and ```sensor-bitdepth``` at construction time. This can be useful to create more meaningful test-cases for our frameworks. In order to prevent headaches with warnings and units and such, the properties have been made ```G_PARAM_CONSTRUCT_ONLY``` in the UcaCamera base class.
Also, I removed the ```__create_random__``` define from mock and made it a gobject property instead. It can be set during acquisition.
Further, the ```uca-camera-control``` GUI was only checking for the ```G_PARAM_WRITABLE``` bit in the properties, but not for ```G_PARAM_CONSTRUC_ONLY``` bit, which invalidates the writable bit. The GUI was changed accordingly.
Lastly, ```test-mock``` was adapted to the new mock behavior.

There is now only one pitfall, though. Since sensor-width and sensor-height are now construction time parameters, the ROI settings need to be set dynamically as well during construction. I just set them to the same values as sensor-width and sensor-height in the initable_init part of mock, which overrides any ROI sized passed in by the user at construction. Do you have any good idea how to handle this properly?