### PR TITLE
Anka plugins for 2.0

### DIFF
--- a/plugins/dexela/CMakeLists.txt
+++ b/plugins/dexela/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 project(ucadexela C)
-set(VERSION "1.3.2")
+set(VERSION "1.3.3")
 
 find_package(DEXELA)
 

--- a/plugins/dexela/CMakeLists.txt
+++ b/plugins/dexela/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 project(ucadexela C)
-set(VERSION "1.3.3")
+set(VERSION "1.4.0")
 
 find_package(DEXELA)
 

--- a/plugins/dexela/CMakeLists.txt
+++ b/plugins/dexela/CMakeLists.txt
@@ -11,7 +11,7 @@ if (DEXELA_FOUND)
     set(PLUGIN_SUMMARY "Dexela plugin for libuca")
     set(PLUGIN_CHANGELOG "${CMAKE_CURRENT_SOURCE_DIR}/changelog.txt")
     set(PLUGIN_DESCRIPTION "Plugin for the Dexela 1207 detector.")
-    set(PLUGIN_REQUIRES "libuca >= 1.3.0, libdexela >= 1.1.0")
+    set(PLUGIN_REQUIRES "libuca >= 2.0.0, libdexela >= 1.2.0")
     set(PLUGIN_VENDOR "ANKA Computing Group")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in

--- a/plugins/dexela/changelog.txt
+++ b/plugins/dexela/changelog.txt
@@ -1,3 +1,7 @@
+* Tue Mar 17 2015 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.3-1
+- adjust the ROI depending on the binning
+* Wed Oct 8 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.2-2
+- new revision for libuca 1.6.0
 * Tue Sep 16 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.2-1
 - implement sensor pixel width and height properties
 * Tue Sep 16 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.1-1

--- a/plugins/dexela/changelog.txt
+++ b/plugins/dexela/changelog.txt
@@ -1,3 +1,6 @@
+* Mon May 18 2015 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.4.0-1
+- Update to libuca 2.0.0
+- Report errors opening the detector instead of crashing
 * Tue Mar 17 2015 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.3-1
 - adjust the ROI depending on the binning
 * Wed Oct 8 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.2-2

--- a/plugins/dexela/uca-dexela-camera.c
+++ b/plugins/dexela/uca-dexela-camera.c
@@ -330,7 +330,7 @@ static void uca_dexela_camera_set_property(GObject *object, guint property_id, c
                 g_warning("Tried to set illegal horizontal binning: %d", horizontalBinning);
                 return;
             }
-            dexela_set_binning_mode(horizontalBinning, dexela_get_binning_mode_vertical());
+            dexela_set_binning_mode(horizontalBinning, horizontalBinning);
             break;
         }
         case PROP_SENSOR_VERTICAL_BINNING:
@@ -340,7 +340,7 @@ static void uca_dexela_camera_set_property(GObject *object, guint property_id, c
                 g_warning("Tried to set illegal vertical binning: %d", verticalBinning);
                 return;
             }
-            dexela_set_binning_mode(dexela_get_binning_mode_horizontal(), verticalBinning);
+            dexela_set_binning_mode(verticalBinning, verticalBinning);
             break;
         }
         case PROP_GAIN_MODE:

--- a/plugins/file/CMakeLists.txt
+++ b/plugins/file/CMakeLists.txt
@@ -5,9 +5,9 @@ find_package(TIFF)
 
 if (TIFF_FOUND)
     set(UCA_CAMERA_NAME "file")
-    set(PLUGIN_VERSION "0.0.1")
-    set(PLUGIN_REVISION "0")
-    set(PLUGIN_REQUIRES "libuca >= 1.2.0")
+    set(PLUGIN_VERSION "0.0.2")
+    set(PLUGIN_REVISION "1")
+    set(PLUGIN_REQUIRES "libuca >= 2.0.0")
     set(PLUGIN_SUMMARY "File plugin for libuca")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in

--- a/plugins/mock/CMakeLists.txt
+++ b/plugins/mock/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 2.6)
 project(ucamock C)
 
 set(UCA_CAMERA_NAME "mock")
-set(PLUGIN_VERSION "1.0.1")
+set(PLUGIN_VERSION "1.0.2")
 set(PLUGIN_REVISION "1")
-set(PLUGIN_REQUIRES "libuca >= 1.2.0")
+set(PLUGIN_REQUIRES "libuca >= 2.0.0")
 set(PLUGIN_SUMMARY "Mock plugin for libuca")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in

--- a/plugins/pco/CMakeLists.txt
+++ b/plugins/pco/CMakeLists.txt
@@ -7,9 +7,9 @@ find_package(ClSerSis)
 
 if (PCO_FOUND)
     set(UCA_CAMERA_NAME "pco")
-    set(PLUGIN_VERSION "1.2.0")
+    set(PLUGIN_VERSION "1.2.1")
     set(PLUGIN_REVISION "1")
-    set(PLUGIN_REQUIRES "libuca >= 1.5.0")
+    set(PLUGIN_REQUIRES "libuca >= 2.0.0")
     set(PLUGIN_SUMMARY "libpco plugin for libuca")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in

--- a/plugins/pf/CMakeLists.txt
+++ b/plugins/pf/CMakeLists.txt
@@ -7,9 +7,9 @@ find_package(ClSerMe4)
 
 if (PF_FOUND AND CLSERME4_FOUND AND FGLIB5_FOUND)
     set(UCA_CAMERA_NAME "pco")
-    set(PLUGIN_VERSION "1.0.0")
+    set(PLUGIN_VERSION "1.0.1")
     set(PLUGIN_REVISION "1")
-    set(PLUGIN_REQUIRES "libuca >= 1.2.0")
+    set(PLUGIN_REQUIRES "libuca >= 2.0.0")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in
                    ${CMAKE_CURRENT_BINARY_DIR}/../../package-plugin-${UCA_CAMERA_NAME}.sh)

--- a/plugins/pylon/CMakeLists.txt
+++ b/plugins/pylon/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 project(ucapylon C)
-set(VERSION "1.3.0")
+set(VERSION "1.4.0")
 
 find_package(Pylon)
 
@@ -11,7 +11,7 @@ if (PYLON_FOUND)
     set(PLUGIN_SUMMARY "Pylon plugin for libuca")
     set(PLUGIN_CHANGELOG "${CMAKE_CURRENT_SOURCE_DIR}/changelog.txt")
     set(PLUGIN_DESCRIPTION "Plugin for the Basler GigE CCD Camera.")
-    set(PLUGIN_REQUIRES "libuca >= 1.3.0, libpyloncam >= 0.5.0")
+    set(PLUGIN_REQUIRES "libuca >= 2.0.0, libpyloncam >= 0.5.0")
     set(PLUGIN_VENDOR "ANKA Computing Group")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in

--- a/plugins/pylon/changelog.txt
+++ b/plugins/pylon/changelog.txt
@@ -1,3 +1,7 @@
+* Mon May 18 2015 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.4.0-1
+- Update to libuca 2.0.0
+* Wed Oct 8 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.0-2
+- new revision for libuca 1.6.0
 * Tue Oct 7 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.3.0-1
 - require libpyloncam 0.5.0 because of new auto exposure feature
 * Thu Sep 11 2014 Mihael Koep <mihael.koep@softwareschneiderei.de> 1.2.1-1

--- a/plugins/pylon/uca-pylon-camera.c
+++ b/plugins/pylon/uca-pylon-camera.c
@@ -68,7 +68,7 @@ static gint base_overrideables[] = {
     PROP_SENSOR_HORIZONTAL_BINNINGS,
     PROP_SENSOR_VERTICAL_BINNING,
     PROP_SENSOR_VERTICAL_BINNINGS,
-    PROP_TRIGGER_MODE,
+    PROP_TRIGGER_SOURCE,
     PROP_EXPOSURE_TIME,
     PROP_ROI_X,
     PROP_ROI_Y,
@@ -149,7 +149,8 @@ static void uca_pylon_camera_set_property(GObject *object, guint property_id, co
       /* intentional fall-through*/
     case PROP_SENSOR_VERTICAL_BINNING:
       /* intentional fall-through*/
-    case PROP_TRIGGER_MODE:
+    case PROP_TRIGGER_SOURCE:
+        /* this plugin supports AUTO triggering only ATM */
         break;
     case PROP_BALANCE_WHITE_AUTO:
     {
@@ -262,8 +263,8 @@ static void uca_pylon_camera_get_property(GObject *object, guint property_id, GV
             g_value_set_boxed(value, priv->binnings);
             break;
 
-        case PROP_TRIGGER_MODE:
-            g_value_set_enum(value, UCA_CAMERA_TRIGGER_AUTO);
+        case PROP_TRIGGER_SOURCE:
+            g_value_set_enum(value, UCA_CAMERA_TRIGGER_SOURCE_AUTO);
             break;
 
         case PROP_HAS_STREAMING:

--- a/plugins/ufo/CMakeLists.txt
+++ b/plugins/ufo/CMakeLists.txt
@@ -5,9 +5,9 @@ find_package(IPE)
 
 if (IPE_FOUND)
     set(UCA_CAMERA_NAME "ufo")
-    set(PLUGIN_VERSION "1.0.1")
+    set(PLUGIN_VERSION "1.0.2")
     set(PLUGIN_REVISION "1")
-    set(PLUGIN_REQUIRES "libuca >= 1.2.0")
+    set(PLUGIN_REQUIRES "libuca >= 2.0.0")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../package-plugin.sh.in
                    ${CMAKE_CURRENT_BINARY_DIR}/../../package-plugin-${UCA_CAMERA_NAME}.sh)


### PR DESCRIPTION
Update to the ANKA-maintained plugins making them compatible with libuca 2.0.
I also updated versions and dependencies for all plugins so they will be installed automatically by the package management system if the user upgrades to libuca 2.x.