### PR TITLE
Allow plugins to check if stop_recording() was called, and end ring buffer thread gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.orig
 *.rpm
 _CPack_Packages
+.vscode/
 build*/
 CMakeFiles
 install_manifest.txt

--- a/src/uca-camera.c
+++ b/src/uca-camera.c
@@ -910,6 +910,21 @@ uca_camera_is_recording (UcaCamera *camera)
 }
 
 /**
+ * uca_camera_stopped_recording:
+ * @camera: A #UcaCamera object
+ * 
+ * Convenience function for plugin's to check if uca_camera_stop_recording() has been called.
+ * 
+ * Return value: %True if state is standby or transitioning from recording to standby
+ */
+gboolean
+uca_camera_stopped_recording(UcaCamera *camera)
+{
+    g_return_val_if_fail (UCA_IS_CAMERA(camera), FALSE);
+    return !uca_camera_is_recording (camera) || camera->priv->cancelling_recording;
+}
+
+/**
  * uca_camera_start_readout:
  * @camera: A #UcaCamera object
  * @error: Location to store a #UcaCameraError error or %NULL

--- a/src/uca-camera.h
+++ b/src/uca-camera.h
@@ -158,6 +158,7 @@ void        uca_camera_start_recording  (UcaCamera          *camera,
 void        uca_camera_stop_recording   (UcaCamera          *camera,
                                          GError            **error);
 gboolean    uca_camera_is_recording     (UcaCamera          *camera);
+gboolean    uca_camera_stopped_recording(UcaCamera          *camera);
 void        uca_camera_start_readout    (UcaCamera          *camera,
                                          GError            **error);
 void        uca_camera_stop_readout     (UcaCamera          *camera,


### PR DESCRIPTION
This change adds a plugin-facing convenience method, ```uca_camera_stopped_recording()``` that returns whether the state should transition from 'recording' to 'standby'. This is useful when using the libuca ring buffer with software or external trigger sources, as you don't need to wait for extra triggers or a potentially long timeout in order to end a recording sequence.

A related change was made to the ```uca_camera_grab()``` method to avoid spin-locking if the buffer thread stopped grabbing frames (e.g. if ```uca_<plugin>_camera_grab()``` returned false).