### PR TITLE
Zmq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,13 @@ pkg_check_modules(GLIB2 glib-2.0>=2.38 REQUIRED)
 pkg_check_modules(GOBJECT2 gobject-2.0>=2.38 REQUIRED)
 pkg_check_modules(GMODULE2 gmodule-2.0>=2.38 REQUIRED)
 pkg_check_modules(GIO2 gio-2.0>=2.38 REQUIRED)
+pkg_check_modules(ZMQ libzmq)
+pkg_check_modules(JSON_GLIB json-glib-1.0)
 
 set(GLIB_VERSION_MIN_REQUIRED "GLIB_VERSION_2_38")
 set(GLIB_VERSION_MAX_ALLOWED "GLIB_VERSION_2_38")
 
-link_directories(${GLIB2_LIBRARY_DIRS})
+link_directories(${GLIB2_LIBRARY_DIRS} ${ZMQ_LIBRARY_DIRS} ${JSON_GLIB_LIBRARY_DIRS})
 #}}}
 #{{{ Common includes
 include_directories(
@@ -85,14 +87,18 @@ include_directories(
     ${GLIB2_INCLUDE_DIRS}
     ${GOBJECT2_INCLUDE_DIRS}
     ${GMODULE2_INCLUDE_DIRS}
-    ${GIO2_INCLUDE_DIRS})
+    ${GIO2_INCLUDE_DIRS}
+    ${ZMQ_INCLUDE_DIRS}
+    ${JSON_GLIB_INCLUDE_DIRS})
 #}}}
 #{{{ Common variables
 set(UCA_DEPS
     ${GLIB2_LIBRARIES}
     ${GOBJECT2_LIBRARIES}
     ${GMODULE2_LIBRARIES}
-    ${GIO2_LIBRARIES})
+    ${GIO2_LIBRARIES}
+    ${ZMQ_LIBRARIES}
+    ${JSON_GLIB_LIBRARIES})
 
 set(UCA_ENUM_HDRS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/uca-camera.h

--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,10 @@ glib_dep = dependency('glib-2.0', version: '>= 2.38')
 gio_dep = dependency('gio-2.0', version: '>= 2.38')
 gobject_dep = dependency('gobject-2.0', version: '>= 2.38')
 gmodule_dep = dependency('gmodule-2.0', version: '>= 2.38')
+zmq_dep = dependency('libzmq', required: false)
+json_dep = dependency('json-glib-1.0', version: '>=1.1.0', required: false)
 
-deps = [glib_dep, gio_dep, gobject_dep, gmodule_dep]
+deps = [glib_dep, gio_dep, gobject_dep, gmodule_dep, zmq_dep, json_dep]
 
 subdir('src')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,9 @@
 option('introspection',
     type: 'boolean', value: true,
     description: 'Build introspection data (requires gobject-introspection')
+
+# For historical reasons upper-case
+option('WITH_PYTHON_MULTITHREADING',
+    type : 'boolean',
+    value : false,
+    description: 'Release Python GIL on long operations')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,9 @@ if (PYTHON_FOUND)
     endif ()
 endif ()
 
+if (ZMQ_FOUND AND JSON_GLIB_FOUND)
+    option(WITH_ZMQ_NETWORKING "Enable sending data over network with zmq" ON)
+endif ()
 #}}}
 #{{{ GObject introspection
 pkg_check_modules(GOBJECT_INTROSPECTION gobject-introspection-1.0)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,3 +1,4 @@
+#cmakedefine WITH_ZMQ_NETWORKING
 #cmakedefine WITH_PYTHON_MULTITHREADING     1
 #cmakedefine HAVE_PCO_CL
 #cmakedefine HAVE_PHOTON_FOCUS

--- a/src/config.h.meson.in
+++ b/src/config.h.meson.in
@@ -1,3 +1,4 @@
+#mesondefine WITH_ZMQ_NETWORKING
 #mesondefine WITH_PYTHON_MULTITHREADING
 #mesondefine UCA_PLUGINDIR
 #mesondefine GLIB_VERSION_MIN_REQUIRED

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,10 @@ if python_dep.found()
   conf.set('WITH_PYTHON_MULTITHREADING', get_option('WITH_PYTHON_MULTITHREADING'))
 endif
 
+if zmq_dep.found() and json_dep.found()
+  conf.set('WITH_ZMQ_NETWORKING', true)
+endif
+
 configure_file(
     input: 'config.h.meson.in',
     output: 'config.h',
@@ -48,7 +52,7 @@ sources += [enums_c, enums_h]
 
 lib = library('uca',
     sources: sources,
-    dependencies: [glib_dep, gobject_dep, gmodule_dep, gio_dep, python_dep],
+    dependencies: deps + [python_dep],
     version: version,
     soversion: version_major,
     install: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,7 +23,8 @@ conf.set('GLIB_VERSION_MIN_REQUIRED', 'GLIB_VERSION_2_38')
 conf.set('GLIB_VERSION_MAX_ALLOWED', 'GLIB_VERSION_2_38')
 
 if python_dep.found()
-  conf.set('WITH_PYTHON_MULTITHREADING', true)
+  message(get_option('WITH_PYTHON_MULTITHREADING'))
+  conf.set('WITH_PYTHON_MULTITHREADING', get_option('WITH_PYTHON_MULTITHREADING'))
 endif
 
 configure_file(

--- a/src/uca-camera.h
+++ b/src/uca-camera.h
@@ -39,6 +39,7 @@ GQuark uca_writable_quark(void);
 
 typedef enum {
     UCA_CAMERA_ERROR_NOT_FOUND,
+    UCA_CAMERA_ERROR_MEMORY_ALLOCATION_FAILURE,
     UCA_CAMERA_ERROR_RECORDING,
     UCA_CAMERA_ERROR_NOT_RECORDING,
     UCA_CAMERA_ERROR_NO_GRAB_FUNC,
@@ -46,6 +47,9 @@ typedef enum {
     UCA_CAMERA_ERROR_WRONG_WRITE_METADATA,
     UCA_CAMERA_ERROR_END_OF_STREAM,
     UCA_CAMERA_ERROR_TIMEOUT,
+    UCA_CAMERA_ERROR_SENDING_UNAVAILABLE,
+    UCA_CAMERA_ERROR_SEND,
+    UCA_CAMERA_ERROR_ENDPOINT_NOT_SPECIFIED,
     UCA_CAMERA_ERROR_DEVICE,
 } UcaCameraError;
 
@@ -104,6 +108,7 @@ enum {
 
     PROP_BUFFERED,
     PROP_NUM_BUFFERS,
+    PROP_ENDPOINT,
     N_BASE_PROPERTIES
 };
 
@@ -144,6 +149,7 @@ struct _UcaCameraClass {
     void (*trigger)         (UcaCamera *camera, GError **error);
     void (*write)           (UcaCamera *camera, const gchar *name, gpointer data, gsize size, GError **error);
     gboolean (*grab)        (UcaCamera *camera, gpointer data, GError **error);
+    gboolean (*grab_send)   (UcaCamera *camera, GError **error);
     gboolean (*readout)     (UcaCamera *camera, gpointer data, guint index, GError **error);
 };
 
@@ -174,6 +180,8 @@ gboolean    uca_camera_grab             (UcaCamera          *camera,
                                          gpointer            data,
                                          GError            **error)
                                         __attribute__((nonnull (2)));
+gboolean    uca_camera_grab_send        (UcaCamera          *camera,
+                                         GError            **error);
 gboolean    uca_camera_readout          (UcaCamera          *camera,
                                          gpointer            data,
                                          guint               index,


### PR DESCRIPTION
Adds *grab_send* which instead of giving images to the user sends them over network. Implemented in the base class and overloaded in uca-net becuase there we want the camera server to push the data, not us.

- [ ] Bump version to 2.4 (and release afterwards)