### PR TITLE
Do not initialize Python

### DIFF
--- a/src/uca-camera.c
+++ b/src/uca-camera.c
@@ -626,10 +626,6 @@ uca_camera_init (UcaCamera *camera)
 
 #ifdef WITH_PYTHON_MULTITHREADING
     g_log (G_LOG_LEVEL_DOMAIN, G_LOG_LEVEL_DEBUG, "Camera initialized with Python support");
-    Py_Initialize();
-    if (PY_MAJOR_VERSION == 2 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 7)) {
-        PyEval_InitThreads();
-    }
 #endif
 }
 


### PR DESCRIPTION
if we are called from pure C code that's desired (e.g. ucad server) and
if we are called from within a python context it must have been
initialzied elsewhere.

An alternative to #89 and ufo-kit/uca-net#15