### PR TITLE
Ignore net-cameras (without postfix index).

### DIFF
--- a/src/uca-plugin-manager.c
+++ b/src/uca-plugin-manager.c
@@ -201,13 +201,14 @@ uca_plugin_manager_get_available_cameras (UcaPluginManager *manager)
 
     return camera_names;
 }
+
 unsigned int get_num_net_cameras(UcaPluginManager *manager) {
     const GList *camera_names = uca_plugin_manager_get_available_cameras(manager);
     unsigned int count = 0;
 
     for (const GList *it = camera_names; it != NULL; it = g_list_next(it)) {
         const gchar *name = it->data;
-        if (g_str_has_prefix(name, "net")) {
+        if (g_str_has_prefix(name, "net") && g_strcmp0(name, "net") != 0) {
             count++;
         }
     }


### PR DESCRIPTION
This fixes the issue that when creating a net camera without having the netX cameras present net0 is tried to be loaded.
Also, if an unclean installation (mixture of net and netX) is present it fixes a wrong numbering of the cameras.